### PR TITLE
Allow using ENV variable as a conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM java:7-jre
 
 # install
 WORKDIR /elasticmq
-RUN wget https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.8.12.jar -O elasticmq-server.jar
+RUN wget https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.9.3.jar -O elasticmq-server.jar
 COPY custom.conf /elasticmq/custom.conf
 COPY logback.xml /elasticmq/logback.xml
 

--- a/custom.conf
+++ b/custom.conf
@@ -4,14 +4,18 @@ include classpath("application.conf")
 node-address {
     protocol = http
     host = sqs
+    host = ${?NODE_HOST}
     port = 80
+    port = ${?NODE_PORT}
     context-path = ""
 }
 
 rest-sqs {
     enabled = true
     bind-port = 80
+    bind-port = ${?BIND_PORT}
     bind-hostname = "0.0.0.0"
+    bind-hostname = ${?BIND_HOST}
     // Possible values: relaxed, strict
     sqs-limits = relaxed
 }


### PR DESCRIPTION
Currently you can only direct messages to the container with a HOST header as "localhost". This has many limitation. 
After this change https://github.com/adamw/elasticmq/commit/2790b84b35b06a25b9c9ae60ec397e01adca7443 you can now specify "*" as a host header to make the server accepts traffic without caring about the HOST
This PR include also an upgrade to the latest available version of elasticmq server (0.9.3)
